### PR TITLE
Use cd-gate Wercker step.

### DIFF
--- a/wercker.yml
+++ b/wercker.yml
@@ -30,12 +30,12 @@ deploy:
         subdomain: usermind
         channel: build
         username: wercker
-        
+
   steps:
-    - script:
-        name: check that deploys are enabled
-        code: |
-          if [ "$(curl http://robbie.internal.usermind.com/hubot/cd/$ENVIRONMENT 2>/dev/null)" != "on" ]; then echo "$ENVIRONMENT deploys are disabled"; exit 1; fi
+    - userminddeployer/cd-gate:
+        endpoint: http://deployments.usermind.com.s3.amazonaws.com/cd
+        environment: $ENVIRONMENT
+        application: storm-metrics-statsd
 
     - userminddeployer/distelli-install
     - script: 


### PR DESCRIPTION
This makes storm-metrics-statsd check its specific flag for the current environment in s3 before deploying. If either `cd/$ENVIRONMENT` or `cd/$ENVIRONMENT/storm-metrics-statsd ` are not `on`, it will block deploy. The purpose is so we can more selectively control deploys in each environment, rather than having a single gating flag for everything.

It also has the benefit of consolidating the code that does the check so we can more easily make improvements in the future. See [skylab/wercker.yml](https://github.com/usermindinc/skylab/blob/master/wercker.yml#L78) for a working example, and [wercker-step-cd-gate](https://github.com/usermindinc/wercker-step-cd-gate) for the logic.

/cc @jreichhold @joweeba 
/fyi @downie